### PR TITLE
fix small Cargo.capacity typo

### DIFF
--- a/src/SpaceTrader/Ship/Cargo.elm
+++ b/src/SpaceTrader/Ship/Cargo.elm
@@ -5,7 +5,7 @@ import SpaceTrader.Ship.Cargo.Item exposing (Item)
 
 
 type alias Cargo =
-    { capcity : Int
+    { capacity : Int
     , units : Int
     , inventory : List Item
     }


### PR DESCRIPTION
Doesn't seem to be used yet, so only a one line change