### PR TITLE
Ship extraction + ship cooldown refreshing

### DIFF
--- a/src/Page/Game.elm
+++ b/src/Page/Game.elm
@@ -975,6 +975,7 @@ view shared model =
                                 { onDock = ShipDockRequested
                                 , onOrbit = ShipOrbitRequested
                                 , onMove = ShipMoveRequested
+                                , onExtract = ShipExtractRequested
                                 }
                             )
                         |> Html.div

--- a/src/Page/Game.elm
+++ b/src/Page/Game.elm
@@ -417,7 +417,7 @@ update ({ model } as opts) =
                 ShipExtractResponded id response ->
                     model
                         |> Update.withResponse response
-                            (\{ extraction, cargo, cooldown } ->
+                            (\{ cargo, cooldown } ->
                                 { model
                                     | myShips =
                                         Dict.update id

--- a/src/SpaceTrader/Api.elm
+++ b/src/SpaceTrader/Api.elm
@@ -1,4 +1,4 @@
-module SpaceTrader.Api exposing (Error(..), Msg(..), PagedMeta, createSurvey, dockShip, extractShip, getAllSystemsInit, getAllSystemsUpdate, getSystem, getWaypoint, moveToOrbit, myAgent, myContracts, myShips, register)
+module SpaceTrader.Api exposing (Error(..), Msg(..), PagedMeta, createSurvey, dockShip, extractShip, getAllSystemsInit, getAllSystemsUpdate, getShipCooldown, getSystem, getWaypoint, moveToOrbit, myAgent, myContracts, myShips, register)
 
 import Http
 import Json.Decode
@@ -150,6 +150,21 @@ extractShip options =
                 (Json.Decode.field "extraction" SpaceTrader.Ship.Extraction.decode)
                 (Json.Decode.field "cooldown" SpaceTrader.Ship.Cooldown.decode)
                 (Json.Decode.field "cargo" SpaceTrader.Ship.Cargo.decode)
+        }
+
+
+getShipCooldown : { token : String, shipId : String } -> Task Error (Maybe SpaceTrader.Ship.Cooldown.Cooldown)
+getShipCooldown options =
+    v2_3
+        { method = "GET"
+        , token = options.token
+        , url = [ "my", "ships", options.shipId, "cooldown" ]
+        , body = Http.emptyBody
+        , decoder =
+            Json.Decode.oneOf
+                [ Json.Decode.maybe SpaceTrader.Ship.Cooldown.decode
+                , Json.Decode.null Nothing
+                ]
         }
 
 

--- a/src/SpaceTrader/Api.elm
+++ b/src/SpaceTrader/Api.elm
@@ -1,4 +1,4 @@
-module SpaceTrader.Api exposing (Error(..), Msg(..), PagedMeta, createSurvey, dockShip, getAllSystemsInit, getAllSystemsUpdate, getSystem, getWaypoint, moveToOrbit, myAgent, myContracts, myShips, register)
+module SpaceTrader.Api exposing (Error(..), Msg(..), PagedMeta, createSurvey, dockShip, extractShip, getAllSystemsInit, getAllSystemsUpdate, getSystem, getWaypoint, moveToOrbit, myAgent, myContracts, myShips, register)
 
 import Http
 import Json.Decode
@@ -10,7 +10,9 @@ import SpaceTrader.Faction exposing (Faction)
 import SpaceTrader.Point.System
 import SpaceTrader.Point.Waypoint
 import SpaceTrader.Ship exposing (Ship)
+import SpaceTrader.Ship.Cargo
 import SpaceTrader.Ship.Cooldown
+import SpaceTrader.Ship.Extraction
 import SpaceTrader.Ship.Nav
 import SpaceTrader.Survey
 import SpaceTrader.System
@@ -127,6 +129,27 @@ dockShip options =
         , url = [ "my", "ships", options.shipId, "dock" ]
         , body = Http.emptyBody
         , decoder = Json.Decode.field "nav" SpaceTrader.Ship.Nav.decode
+        }
+
+
+extractShip : { token : String, shipId : String } -> Task Error { extraction : SpaceTrader.Ship.Extraction.Extraction, cooldown : SpaceTrader.Ship.Cooldown.Cooldown, cargo : SpaceTrader.Ship.Cargo.Cargo }
+extractShip options =
+    v2_3
+        { method = "POST"
+        , token = options.token
+        , url = [ "my", "ships", options.shipId, "extract" ]
+        , body = Http.emptyBody
+        , decoder =
+            Json.Decode.map3
+                (\extraction cooldown cargo ->
+                    { extraction = extraction
+                    , cooldown = cooldown
+                    , cargo = cargo
+                    }
+                )
+                (Json.Decode.field "extraction" SpaceTrader.Ship.Extraction.decode)
+                (Json.Decode.field "cooldown" SpaceTrader.Ship.Cooldown.decode)
+                (Json.Decode.field "cargo" SpaceTrader.Ship.Cargo.decode)
         }
 
 

--- a/src/SpaceTrader/Ship/Extraction.elm
+++ b/src/SpaceTrader/Ship/Extraction.elm
@@ -1,0 +1,17 @@
+module SpaceTrader.Ship.Extraction exposing (Extraction, decode)
+
+import Json.Decode
+import SpaceTrader.Ship.Yield
+
+
+type alias Extraction =
+    { shipId : String
+    , yield : SpaceTrader.Ship.Yield.Yield
+    }
+
+
+decode : Json.Decode.Decoder Extraction
+decode =
+    Json.Decode.map2 Extraction
+        (Json.Decode.field "shipSymbol" Json.Decode.string)
+        (Json.Decode.field "yield" SpaceTrader.Ship.Yield.decode)

--- a/src/SpaceTrader/Ship/Yield.elm
+++ b/src/SpaceTrader/Ship/Yield.elm
@@ -1,0 +1,17 @@
+module SpaceTrader.Ship.Yield exposing (Yield, decode)
+
+import Json.Decode
+
+
+type alias Yield =
+    { symbol : String
+    , units : Int
+    }
+
+
+decode : Json.Decode.Decoder Yield
+decode =
+    Json.Decode.map2 Yield
+        (Json.Decode.field "symbol" Json.Decode.string)
+        (Json.Decode.field "units" Json.Decode.int)
+

--- a/src/Ui.elm
+++ b/src/Ui.elm
@@ -175,6 +175,7 @@ progress attr opt =
             [ Html.Attributes.style "width" (String.fromFloat (opt.current / opt.max * 100) ++ "%")
             , Html.Attributes.style "height" "100%"
             , Html.Attributes.style "background-color" "var(--blue-dark)"
+            , Html.Attributes.style "transition" "width 0.5s ease-in-out"
             ]
             []
         ]

--- a/src/Ui/Ship.elm
+++ b/src/Ui/Ship.elm
@@ -6,6 +6,7 @@ import Route
 import SpaceTrader.Point.System
 import SpaceTrader.Point.Waypoint
 import SpaceTrader.Ship
+import SpaceTrader.Ship.Cooldown
 import SpaceTrader.Ship.Nav.Status
 import Ui
 import Ui.Button
@@ -18,6 +19,7 @@ view :
     , onOrbit : String -> msg
     , onMove : String -> msg
     , onExtract : String -> msg
+    , onRefreshCooldown : String -> msg
     }
     -> SpaceTrader.Ship.Ship
     -> Html msg
@@ -82,7 +84,12 @@ view opts ship =
           else
             Ui.none
         , if ship.nav.status == SpaceTrader.Ship.Nav.Status.InOrbit then
-            Ui.Button.default [] { label = Html.text "Extract", onClick = Just <| opts.onExtract ship.id }
+            case ship.cooldown of
+                Just _ ->
+                    Ui.Button.default [] { label = Html.text "Refresh Cooldown", onClick = Just <| opts.onRefreshCooldown ship.id }
+
+                Nothing ->
+                    Ui.Button.default [] { label = Html.text "Extract", onClick = Just <| opts.onExtract ship.id }
 
           else
             Ui.none

--- a/src/Ui/Ship.elm
+++ b/src/Ui/Ship.elm
@@ -80,12 +80,12 @@ view opts ship =
             Html.span [ Html.Attributes.style "font-weight" "bold" ] [ Html.text "Action:" ]
 
           else
-            Html.text ""
+            Ui.none
         , if ship.nav.status == SpaceTrader.Ship.Nav.Status.InOrbit then
             Ui.Button.default [] { label = Html.text "Extract", onClick = Just <| opts.onExtract ship.id }
 
           else
-            Html.text ""
+            Ui.none
         , Html.span [ Html.Attributes.style "font-weight" "bold" ] [ Html.text "Cargo:" ]
         , Html.span [] [ Ui.Ship.Cargo.view ship.cargo ]
         ]

--- a/src/Ui/Ship.elm
+++ b/src/Ui/Ship.elm
@@ -6,7 +6,9 @@ import Route
 import SpaceTrader.Point.System
 import SpaceTrader.Point.Waypoint
 import SpaceTrader.Ship
+import SpaceTrader.Ship.Nav.Status
 import Ui
+import Ui.Button
 import Ui.Ship.Cargo
 import Ui.Ship.Nav.Status
 
@@ -73,6 +75,16 @@ view opts ship =
                 }
                 ship.nav.status
             ]
+        , if ship.nav.status == SpaceTrader.Ship.Nav.Status.InOrbit then
+            Html.span [ Html.Attributes.style "font-weight" "bold" ] [ Html.text "Action:" ]
+
+          else
+            Html.text ""
+        , if ship.nav.status == SpaceTrader.Ship.Nav.Status.InOrbit then
+            Ui.Button.default [] { label = Html.text "Extract", onClick = Nothing }
+
+          else
+            Html.text ""
         , Html.span [ Html.Attributes.style "font-weight" "bold" ] [ Html.text "Cargo:" ]
         , Html.span [] [ Ui.Ship.Cargo.view ship.cargo ]
         ]

--- a/src/Ui/Ship.elm
+++ b/src/Ui/Ship.elm
@@ -79,17 +79,25 @@ view opts ship =
                 ship.nav.status
             ]
         , if ship.nav.status == SpaceTrader.Ship.Nav.Status.InOrbit then
-            Html.span [ Html.Attributes.style "font-weight" "bold" ] [ Html.text "Action:" ]
+            Html.span
+                [ Html.Attributes.style "font-weight" "bold" ]
+                [ Html.text "Action:" ]
 
           else
             Ui.none
         , if ship.nav.status == SpaceTrader.Ship.Nav.Status.InOrbit then
             case ship.cooldown of
                 Just _ ->
-                    Ui.Button.default [] { label = Html.text "Refresh Cooldown", onClick = Just <| opts.onRefreshCooldown ship.id }
+                    Ui.Button.default []
+                        { label = Html.text "Refresh Cooldown"
+                        , onClick = Just <| opts.onRefreshCooldown ship.id
+                        }
 
                 Nothing ->
-                    Ui.Button.default [] { label = Html.text "Extract", onClick = Just <| opts.onExtract ship.id }
+                    Ui.Button.default []
+                        { label = Html.text "Extract"
+                        , onClick = Just <| opts.onExtract ship.id
+                        }
 
           else
             Ui.none

--- a/src/Ui/Ship.elm
+++ b/src/Ui/Ship.elm
@@ -17,6 +17,7 @@ view :
     { onDock : String -> msg
     , onOrbit : String -> msg
     , onMove : String -> msg
+    , onExtract : String -> msg
     }
     -> SpaceTrader.Ship.Ship
     -> Html msg
@@ -81,7 +82,7 @@ view opts ship =
           else
             Html.text ""
         , if ship.nav.status == SpaceTrader.Ship.Nav.Status.InOrbit then
-            Ui.Button.default [] { label = Html.text "Extract", onClick = Nothing }
+            Ui.Button.default [] { label = Html.text "Extract", onClick = Just <| opts.onExtract ship.id }
 
           else
             Html.text ""

--- a/src/Ui/Ship.elm
+++ b/src/Ui/Ship.elm
@@ -6,7 +6,6 @@ import Route
 import SpaceTrader.Point.System
 import SpaceTrader.Point.Waypoint
 import SpaceTrader.Ship
-import SpaceTrader.Ship.Cooldown
 import SpaceTrader.Ship.Nav.Status
 import Ui
 import Ui.Button


### PR DESCRIPTION
![image](https://github.com/wolfadex/space-traders-ui/assets/1312390/4ae44ac7-0e50-42df-90b7-da7a1b6b1b69)

When orbiting a waypoint, the 'action' row reveals itself and lets you extract resources. If there's a cooldown, the button instead changes to a 'refresh cooldown' button, which hits the API and refreshes the cooldown.

Since [`/ships/symbol/cooldown`](https://spacetraders.stoplight.io/docs/spacetraders/d20ef14bc0742-get-ship-cooldown) returns a 204 with an empty body when there's no cooldown, this PR adds `v2_3_nobody` to provide a fallback value in that case.

I think could be improved are the lack of a type for the `{extraction, cooldown, cargo}` response. I didn't add one because I felt like type was limited to just this one case, and wasn't worth adding to `Ship/`.

Also this adds a short transition to all `UI.progress` bars that add a nice little touch.

Next steps if anyone is looking to jump in:

* Allow for selling cargo at a docked marketplace once full
* Detecting whether you're full on cargo and can't extract
* Passing specific cargo you wish to extract